### PR TITLE
Modify Gemfile to use Ruby 2.0, which should play nicer with Rails 4.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.0.0'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.1'
 


### PR DESCRIPTION
As agreed to in the meeting, this will force Heroku to use a version of Ruby which should avoid problems with Rails.
