### PR TITLE
Fix Rubocop offenses from outside todo file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,19 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+
+Rails:
+  Enabled: true
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: false
 
-  AllCops:
-    - Rakefile
-    - config.ru
-  
-  Rails:
-    Enabled: true
+Style/Documentation:
+  Enabled: false

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,35 +1,35 @@
 class GamesController < ApplicationController
-	before_action :authenticate_user!
+  before_action :authenticate_user!
 
-	def index
-		@games = Game.all
-	end
+  def index
+    @games = Game.all
+  end
 
-	def new
-		@game = Game.new
-	end
+  def new
+    @game = Game.new
+  end
 
-	def create
-		@game = Game.create(game_params)
-		@game.white_player_id = current_user.id
-		@game.save
-		redirect_to game_path(@game)
-	end
+  def create
+    @game = Game.create(game_params)
+    @game.white_player_id = current_user.id
+    @game.save
+    redirect_to game_path(@game)
+  end
 
-	def show
-		@game = Game.find(params[:id])
-	end
+  def show
+    @game = Game.find(params[:id])
+  end
 
-	def update
-	end
+  def update
+  end
 
-	private
+  private
 
-	def game_params
-		params.require(:game).permit(:name)
-	end
+  def game_params
+    params.require(:game).permit(:name)
+  end
 
-	# def game_params
-	#	  params.require(:game).permit(:name, :white_player_id, :black_player_id)
-	# end
+  # def game_params
+  #   params.require(:game).permit(:name, :white_player_id, :black_player_id)
+  # end
 end


### PR DESCRIPTION
This commit addresses most of the current Rubocop infractions that keep putting Xes next to all of our pull requests. I've changed the following:
- Adjust the spacing in games_controller.rb to remove tab characters. (This is the only change to the actual code base, and there should be no difference in functionality.)
- Disable the Style/Documentation cop that insists on top-level class documentation comments, which don't really make much sense for a Rails project.
- Exclude all files from the db and config folders, via code lifted from the Rubocop README.

After these changes, the only Rubocop offenses shown are from the enrollments_controller.rb file, which is about to be deleted via another pull request. After this, we should probably make sure that we get check marks from Travis before merging, so as to avoid adding any more offenses. Then I (and/or someone else) can work on fixing the stuff in the .rubocop_todo.yml list in the near future.
