### PR TITLE
Fix unresolved merge conflict to eliminate error when running Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 inherit_from: .rubocop_todo.yml
-<<<<<<< HEAD
 
 AllCops:
   Include:
@@ -8,6 +7,8 @@ AllCops:
   Exclude:
     - 'db/**/*'
     - 'config/**/*'
+    - 'script/**/*'
+    - 'vendor/**/*'
 
 Rails:
   Enabled: true
@@ -18,22 +19,9 @@ Style/StringLiterals:
 
 Style/Documentation:
   Enabled: false
-=======
-Documentation:
-  Enabled: false
-EndOfLine:
-  Enabled: false
-Rails:
-  Enabled: true
-Style/LeadingCommentSpace:
+
+Style/EndOfLine:
   Enabled: false
 
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-    - 'vendor/**/*'
->>>>>>> rubocop
+Style/LeadingCommentSpace:
+  Enabled: false


### PR DESCRIPTION
The version of .rubocop.yml in master had merge-conflict symbols still in it, which caused an error to be thrown upon running Rubocop. This branch removes those symbols and the duplicate code, keeping the additions made in both previous commits. (Now, Rubocop is back to complaining about tabs in the games controller. Progress!)
