### PR TITLE
En passant

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -22,13 +22,9 @@ class Pawn < Piece
   end
 
   def valid_double_move?(new_x, new_y)
-    origin_row = (color == 'white') ? 2 : 7
-    passed_row = (color == 'white') ? 3 : 6
-
-    return false unless y_coord == origin_row
-    return false if game.piece_at(new_x, passed_row)
-    return false if game.piece_at(new_x, new_y)
-    true
+    return false unless y_coord == nth_rank(2)
+    return false if game.piece_at(new_x, nth_rank(3))
+    !game.piece_at(new_x, new_y)
   end
 
   def valid_capture?(new_x, new_y)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -15,6 +15,23 @@ class Pawn < Piece
     false
   end
 
+  # This is an addition to the move_to! method in the Piece model.
+  # It destroys a pawn that has been captured en passant, determines whether
+  # the current pawn is vulnerable to en passant capture, and adds a
+  # placeholder for pawn promotion.
+  def move_to!(destination_x, destination_y)
+    capture_en_passant!(destination_x, destination_y)
+
+    # If the pawn is advancing two squares, it my be captured en passant.
+    en_passant_file = (destination_y - y_coord).abs == 2 ? x_coord : nil
+    game.update_attribute(:en_passant_file, en_passant_file)
+
+    super
+
+    # TODO: Implement the promote! method.
+    # promote! if y_coord == nth_rank(8)
+  end
+
   private
 
   def valid_standard_move?(new_x, new_y)
@@ -42,5 +59,20 @@ class Pawn < Piece
     # two squares on the destination file. If this is the case,
     # game.en_passant_file will equal the destination file.
     game.en_passant_file == new_x
+  end
+
+  def capture_en_passant!(destination_x, destination_y)
+    # If the pawn's x value is changing, the move must be a capture.
+    # If the destination rank is the current player's sixth rank (the enemy's
+    # third), and the last move was a two-square advance by a pawn on the
+    # destination file, it must be en passant. In that case, capture the enemy
+    # pawn, which is currently on the starting rank of the moving pawn.
+    if destination_x != x_coord &&
+       destination_y == nth_rank(6) &&
+       game.reload.en_passant_file == destination_x
+
+      # raise "#{game.reload.en_passant_file} == #{destination_x}"
+      game.piece_at(destination_x, y_coord).destroy
+    end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -28,7 +28,19 @@ class Pawn < Piece
   end
 
   def valid_capture?(new_x, new_y)
+    # If there is a piece at the destination, the capture is valid if it's an
+    # enemy piece, and invalid if friendly. Otherwise, determine whether an
+    # en passant capture is possible.
     destination_piece = game.piece_at(new_x, new_y)
-    destination_piece.present? && destination_piece.color != color
+    return destination_piece.color != color if destination_piece
+
+    # To make an en passant capture, the pawn must start on its fifth rank
+    # (i.e., have a y_coord of 5 if white, or 4 if black)...
+    return false unless y_coord == nth_rank(5)
+
+    # ...and the immediately-preceding move must have been a pawn advancing
+    # two squares on the destination file. If this is the case,
+    # game.en_passant_file will equal the destination file.
+    game.en_passant_file == new_x
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -58,7 +58,7 @@ class Pawn < Piece
     # ...and the immediately-preceding move must have been a pawn advancing
     # two squares on the destination file. If this is the case,
     # game.en_passant_file will equal the destination file.
-    game.en_passant_file == new_x
+    game.reload.en_passant_file == new_x
   end
 
   def capture_en_passant!(destination_x, destination_y)
@@ -71,7 +71,6 @@ class Pawn < Piece
        destination_y == nth_rank(6) &&
        game.reload.en_passant_file == destination_x
 
-      # raise "#{game.reload.en_passant_file} == #{destination_x}"
       game.piece_at(destination_x, y_coord).destroy
     end
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -22,7 +22,7 @@ class Pawn < Piece
   def move_to!(destination_x, destination_y)
     capture_en_passant!(destination_x, destination_y)
 
-    # If the pawn is advancing two squares, it my be captured en passant.
+    # If the pawn is advancing two squares, it may be captured en passant.
     en_passant_file = (destination_y - y_coord).abs == 2 ? x_coord : nil
     game.update_attribute(:en_passant_file, en_passant_file)
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -97,4 +97,12 @@ class Piece < ActiveRecord::Base
 
     x_offset.abs == y_offset.abs
   end
+
+  # Given the rank from the current player's perspective, returns the
+  # corresponding y value. For example, pawns start on the player's second
+  # rank, which is 2 for White and 7 for Black. Therefore, nth_rank(2)
+  # returns 2 if the piece is white, and 7 if it's black.
+  def nth_rank(n)
+    color == 'white' ? n : 9 - n
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,10 +17,17 @@ class Piece < ActiveRecord::Base
     return false unless valid_move?(destination_x, destination_y)
     destination_piece = game.piece_at(destination_x, destination_y)
 
+    # If the destination piece is friendly, reject the move.
+    # Otherwise, capture the destination piece.
     if destination_piece
       return false if destination_piece.color == color
       destination_piece.destroy
     end
+
+    # If the move is not being made by a pawn, en passant capture is not
+    # possible on the next move. If it is being made by a pawn, the move_to!
+    # method in the Pawn class will set this value appropriately.
+    game.update_attribute(:en_passant_file, nil) unless is_a? Pawn
 
     update_attributes!(x_coord: destination_x, y_coord: destination_y)
   end

--- a/db/migrate/20160603182320_add_en_passant_file_to_games.rb
+++ b/db/migrate/20160603182320_add_en_passant_file_to_games.rb
@@ -1,0 +1,5 @@
+class AddEnPassantFileToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :en_passant_file, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160522191002) do
+ActiveRecord::Schema.define(version: 20160603182320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20160522191002) do
     t.datetime "updated_at"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
+    t.integer  "en_passant_file"
   end
 
   create_table "pieces", force: true do |t|

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Pawn, type: :model do
+  context "when set up for en passant" do
+    let(:game) { Game.create! }
+    let(:white_pawn_2) { game.piece_at(2, 2) }
+    let(:black_pawn_3) { game.piece_at(3, 7) }
+    let(:white_pawn_5) { game.piece_at(5, 2) }
+    let(:black_pawn_6) { game.piece_at(6, 7) }
+    let(:white_knight) { game.piece_at(7, 1) }
+    let(:black_knight) { game.piece_at(7, 8) }
+
+    it "allows valid en passant capture" do
+      white_pawn_2.move_to!(2, 4)
+      black_knight.move_to!(8, 6)
+      white_pawn_2.move_to!(2, 5)
+      black_pawn_3.move_to!(3, 5)
+      expect(white_pawn_2.valid_move?(3, 6)).to be true
+      white_pawn_2.move_to!(3, 6)
+      expect { black_pawn_3.reload }.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+    end
+
+    it "disallows e.p. capture after another move has been made" do
+      black_pawn_6.move_to!(6, 5)
+      white_knight.move_to!(8, 3)
+      black_pawn_6.move_to!(6, 4)
+      white_pawn_5.move_to!(5, 4)
+      black_knight.move_to!(8, 6)
+      white_knight.move_to!(7, 5)
+      expect(black_pawn_6.valid_move?(5, 3)).to be false
+      # This will work properly when valid_move? is required by move_to!:
+      # expect(black_pawn_6.move_to!(5, 3)).to be false
+      expect(white_pawn_5.reload.id).to be_a Integer
+    end
+  end
+end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -4,35 +4,70 @@ RSpec.describe Pawn, type: :model do
   context "when set up for en passant" do
     let(:game) { Game.create! }
     let(:white_pawn_2) { game.piece_at(2, 2) }
-    let(:black_pawn_3) { game.piece_at(3, 7) }
+    let(:black_pawn_1) { game.piece_at(1, 7) }
     let(:white_pawn_5) { game.piece_at(5, 2) }
     let(:black_pawn_6) { game.piece_at(6, 7) }
     let(:white_knight) { game.piece_at(7, 1) }
     let(:black_knight) { game.piece_at(7, 8) }
+    let(:black_pawn_3) { game.piece_at(3, 7) }
+    let(:white_bishop) { game.piece_at(6, 1) }
 
     it "allows valid en passant capture" do
       white_pawn_2.move_to!(2, 4)
+      # Inconsequential move to bypass Black's turn:
       black_knight.move_to!(8, 6)
       white_pawn_2.move_to!(2, 5)
-      black_pawn_3.move_to!(3, 5)
-      expect(white_pawn_2.valid_move?(3, 6)).to be true
-      white_pawn_2.move_to!(3, 6)
-      expect { black_pawn_3.reload }.to raise_error(
+      # Two-square advance:
+      black_pawn_1.move_to!(1, 5)
+      # Capture:
+      expect(white_pawn_2.valid_move?(1, 6)).to be true
+      white_pawn_2.move_to!(1, 6)
+      expect { black_pawn_1.reload }.to raise_error(
         ActiveRecord::RecordNotFound
       )
     end
 
     it "disallows e.p. capture after another move has been made" do
-      black_pawn_6.move_to!(6, 5)
+      # Inconsequential move to bypass White's turn:
       white_knight.move_to!(8, 3)
+      black_pawn_6.move_to!(6, 5)
+      # Ditto:
+      white_knight.move_to!(7, 1)
       black_pawn_6.move_to!(6, 4)
+      # Two-square advance:
       white_pawn_5.move_to!(5, 4)
+      # Completely-unrelated moves by each player:
       black_knight.move_to!(8, 6)
-      white_knight.move_to!(7, 5)
+      white_knight.move_to!(8, 3)
+      # Invalid capture:
       expect(black_pawn_6.valid_move?(5, 3)).to be false
-      # This will work properly when valid_move? is required by move_to!:
-      # expect(black_pawn_6.move_to!(5, 3)).to be false
+      expect(black_pawn_6.move_to!(5, 3)).to be false
       expect(white_pawn_5.reload.id).to be_a Integer
+    end
+
+    it "disallows e.p. capture by a non-pawn" do
+      white_pawn_5.move_to!(5, 4)
+      # Inconsequential move to bypass Black's turn:
+      black_knight.move_to!(8, 6)
+      white_bishop.move_to!(2, 5)
+      # Two-square advance:
+      black_pawn_3.move_to!(3, 5)
+      # Invalid capture:
+      white_bishop.move_to!(3, 6)
+      expect(black_pawn_3.reload.id).to be_a Integer
+    end
+
+    it "disallows e.p. capture without a two-square advance" do
+      white_pawn_2.move_to!(2, 4)
+      # One-square advance:
+      black_pawn_1.move_to!(1, 6)
+      white_pawn_2.move_to!(2, 5)
+      # A second one-square advance:
+      black_pawn_1.move_to!(1, 5)
+      # Invalid capture:
+      expect(white_pawn_2.valid_move?(1, 6)).to be false
+      expect(white_pawn_2.move_to!(1, 6)).to be false
+      expect(black_pawn_1.reload.id).to be_a Integer
     end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pawn, type: :model do
     let(:black_pawn_3) { game.piece_at(3, 7) }
     let(:white_bishop) { game.piece_at(6, 1) }
 
-    it "allows valid en passant capture" do
+    it "allows valid en passant capture by White" do
       white_pawn_2.move_to!(2, 4)
       # Inconsequential move to bypass Black's turn:
       black_knight.move_to!(8, 6)
@@ -25,6 +25,27 @@ RSpec.describe Pawn, type: :model do
       expect { black_pawn_1.reload }.to raise_error(
         ActiveRecord::RecordNotFound
       )
+      expect(white_pawn_2.x_coord).to eq 1
+      expect(white_pawn_2.y_coord).to eq 6
+    end
+
+    it "allows valid en passant capture by Black" do
+      # Inconsequential move to bypass White's turn:
+      white_knight.move_to!(8, 3)
+      black_pawn_6.move_to!(6, 5)
+      # Ditto:
+      white_knight.move_to!(7, 1)
+      black_pawn_6.move_to!(6, 4)
+      # Two-square advance:
+      white_pawn_5.move_to!(5, 4)
+      # Capture:
+      expect(black_pawn_6.valid_move?(5, 3)).to be true
+      black_pawn_6.move_to!(5, 3)
+      expect { white_pawn_5.reload }.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+      expect(black_pawn_6.x_coord).to eq 5
+      expect(black_pawn_6.x_coord).to eq 3
     end
 
     it "disallows e.p. capture after another move has been made" do

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Pawn, type: :model do
         ActiveRecord::RecordNotFound
       )
       expect(black_pawn_6.x_coord).to eq 5
-      expect(black_pawn_6.x_coord).to eq 3
+      expect(black_pawn_6.y_coord).to eq 3
     end
 
     it "disallows e.p. capture after another move has been made" do


### PR DESCRIPTION
This branch adds the ability for a pawn to capture another pawn [en passant](https://en.wikipedia.org/wiki/En_passant). (In short, a pawn that advances two squares from its initial position may, on the very next move, be captured by an enemy pawn as though the former had advanced only one square.)

![anim](https://cloud.githubusercontent.com/assets/17390227/15801863/57d0c940-2a70-11e6-88c9-f74173b519c8.gif)

This branch:
- Adds an en_passant_file column to the games table, which tracks whether an en passant capture is legal, and updates this value in the move_to! method.
- Updates the Pawn class's valid_move? helper methods.
- Creates a Pawn-class move_to! method, which executes the Piece model's move_to! method, and removes an en-passant-captured pawn, if applicable.
