### PR TITLE
Use stable version of RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem 'rails', '4.0.1'
 # Use postgresql as the database for Active Record
 gem 'pg'
 
+# RSpec
 group :development, :test do
+  gem 'rspec-rails', '~> 3.0'
   gem 'pry-nav'
 end
 
@@ -62,8 +64,3 @@ end
 
 # Use rails_12factor gem for easier production deployment
 gem 'rails_12factor', group: :production
-
-# Per rspec docs, these need to be included to run against the master branch
-%w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,3 @@
-GIT
-  remote: https://github.com/rspec/rspec-core.git
-  revision: bc1482605763cc16efa55c98b8da64a89c8ff5f9
-  branch: master
-  specs:
-    rspec-core (3.5.0.pre)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-expectations.git
-  revision: 56a7598fd870d2bcf385241c666d6ca0b9d17b21
-  branch: master
-  specs:
-    rspec-expectations (3.5.0.pre)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-mocks.git
-  revision: 5ccf92597a6cfa3aca3d37ed29c0162ed3845a5e
-  branch: master
-  specs:
-    rspec-mocks (3.5.0.pre)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-rails.git
-  revision: b019fdd96f46b325ef2ea3a1d82812bbbc706f4c
-  branch: master
-  specs:
-    rspec-rails (3.5.0.pre)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (= 3.5.0.pre)
-      rspec-expectations (= 3.5.0.pre)
-      rspec-mocks (= 3.5.0.pre)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-support.git
-  revision: 46055576b22461ca61ef41e4ceb370867753e517
-  branch: master
-  specs:
-    rspec-support (3.5.0.pre)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -73,8 +26,8 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.2)
-    ast (2.2.0)
-    autoprefixer-rails (6.3.6)
+    ast (2.3.0)
+    autoprefixer-rails (6.3.6.2)
       execjs
     bcrypt (3.1.11)
     bootstrap-sass (3.3.5.1)
@@ -89,7 +42,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    devise (3.5.9)
+    devise (3.5.10)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -98,7 +51,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     hike (1.2.3)
     i18n (0.7.0)
     jbuilder (1.5.3)
@@ -116,9 +69,9 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (4.7.5)
-    multi_json (1.12.0)
+    multi_json (1.12.1)
     orm_adapter (0.5.0)
-    parser (2.3.1.0)
+    parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
     polyglot (0.3.5)
@@ -156,13 +109,30 @@ GEM
       json (~> 1.4)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-rails (3.4.2)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     rubocop (0.40.0)
       parser (>= 2.3.1.0, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.0)
+    ruby-progressbar (1.8.1)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -215,11 +185,7 @@ DEPENDENCIES
   pry-nav
   rails (= 4.0.1)
   rails_12factor
-  rspec-core!
-  rspec-expectations!
-  rspec-mocks!
-  rspec-rails!
-  rspec-support!
+  rspec-rails (~> 3.0)
   rubocop (~> 0.40.0)
   sass-rails
   sdoc
@@ -232,4 +198,4 @@ RUBY VERSION
    ruby 2.0.0p353
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ RSpec.configure do |config|
   # compatibility in RSpec 3). It causes shared context metadata to be
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
-  config.shared_context_metadata_behavior = :apply_to_host_groups
+  # config.shared_context_metadata_behavior = :apply_to_host_groups
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
This branch fixes a mistake introduced after a misread of the RSpec docs, which resulted in us running RSpec's master branch. This fix will have us running the most recent release of RSpec 3.
