### PR TITLE
Castling

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,6 +6,15 @@ class Game < ActiveRecord::Base
 
   after_create :setup_board!
 
+  # Helper method used to determine if a particular square is under potential attack.
+  def square_threatened_by?(color, destination_x, destination_y)
+    enemy_pieces = pieces.where(color: color)
+    enemy_pieces.each do |piece|
+      return true if piece.valid_move?(destination_x, destination_y)
+    end
+    false
+  end
+
   # Determine if the king is being moved into a position resulting in check.
   def in_check?(color)
     # Find the active player's king
@@ -23,15 +32,6 @@ class Game < ActiveRecord::Base
   end
 
   private
-
-  # Helper method used to determine if a particular square is under potential attack.
-  def square_threatened_by?(color, destination_x, destination_y)
-    enemy_pieces = pieces.where(color: color)
-    enemy_pieces.each do |piece|
-      return true if piece.valid_move?(destination_x, destination_y)
-    end
-    false
-  end
 
   def setup_board!
     %w(white black).each do |color|

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -4,9 +4,7 @@ class King < Piece
     return false if current_square?(new_x, new_y)
 
     x_offset, y_offset = movement_by_axis(new_x, new_y)
-    return true if (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)
-
-    valid_castling?(new_x, new_y)
+    (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset) || valid_castling?(new_x, new_y)
   end
 
   # An addition to the move_to! method found within the Piece model.
@@ -54,12 +52,12 @@ class King < Piece
 
   # Castling helper method.
   def rook_requirements_met?(new_x, new_y)
-    # Set the file for the rook to 1 if the player's intent is to Castle queen-side,
-    # otherwise it will be set to eight. File is a chess term that's analogous to x_coord.
-    rook_file = new_x == 3 ? 1 : 8
+    # Set the x_coord for the rook to 1 if the player's intent is to Castle queen-side,
+    # otherwise it will be set to eight.
+    rook_x_coord = new_x == 3 ? 1 : 8
 
     # Assign a variable to the piece found in the rook's square.
-    rook = game.piece_at(rook_file, new_y)
+    rook = game.piece_at(rook_x_coord, new_y)
 
     # Guard against the rook's square being empty, or some other piece.
     return false unless rook.is_a? Rook
@@ -68,7 +66,7 @@ class King < Piece
     return false if rook.moved?
 
     # Castling is prevented temporarily if there is any piece between the king and the rook.
-    !obstructed?(rook_file, new_y)
+    !obstructed?(rook_x_coord, new_y)
   end
 
   # Castling is prevented temporarily:
@@ -76,15 +74,12 @@ class King < Piece
   # or the square which it is to occupy, is attacked by one or more of the opponent's pieces.
   def king_traversal_under_attack?(new_x, new_y)
     # The argument for new_x will be either 3 or 7 if castling is attempted.
-    king_file_array = (new_x == 3) ? [3, 4, 5] : [5, 6, 7]
+    king_x_array = (new_x == 3) ? [3, 4, 5] : [5, 6, 7]
 
     # square_threatened_by? takes color as one of its arguments.
     opponent_color = (color == 'white') ? 'black' : 'white'
 
     # Determine if any squares from the king's origin to his destination are under threat.
-    king_file_array.each do |file|
-      return true if game.square_threatened_by?(opponent_color, file, new_y)
-    end
-    false
+    king_x_array.any? { |x_coord| game.square_threatened_by?(opponent_color, x_coord, new_y) }
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -12,32 +12,36 @@ class King < Piece
 
   private
 
-
   # Determine if castling is allowed.
   def valid_castling?(new_x, new_y)
     # The right to castle has been lost if the king has moved.
     return false if moved?
 
     # Castling is permitted if the king and the chosen rook are on the player's first rank.
-    return false unless nth_rank(1) == new_y
+    # Since the king hasn't moved, then y_coord will be the same as the player's first rank.
+    return false unless y_coord == new_y
 
     # Castling is not permitted unless the king moves two spaces along the same rank.
     return false unless new_x == 3 || new_x == 7
 
     # Castling is not permitted if the rook has moved, or if there are any obstructions.
-    rook_file(new_x, new_y)
-  end
+    return false unless rook_requirements(new_x, new_y)
 
-  # Ensures that Castling is only permitted on the first rank relative to the player.
-  def nth_rank(n)
-    color == 'white' ? n : 9 - n
+    # Allows Castling if the squares that the king traverses are not under attack.
+    !king_traversal_under_attack?(new_x, new_y)
   end
 
   # Castling helper method.
-  def rook_file(new_x, new_y)
+  def rook_requirements(new_x, new_y)
     # Set the file for the rook to 1 if the player's intent is to Castle queen-side,
     # otherwise it will be set to eight.
     rook_file = new_x == 3 ? 1 : 8
+
+    # Guard against the rook's square being empty.
+    return false if game.piece_at(rook_file, new_y) == nil
+
+    # Assign a variable to the piece found in the rook's square. This handles either situation
+    # whether the piece is a rook or not.
     rook = game.piece_at(rook_file, new_y)
 
     # The right to castle has been lost if the rook has moved earlier in the game.

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,6 +1,5 @@
 class King < Piece
-  # This method does not yet consider castling, and does not
-  # disallow a king from moving into check.
+  # This method does not disallow a king from moving into check.
   def valid_move?(new_x, new_y)
     return false if off_board?(new_x, new_y)
     return false if current_square?(new_x, new_y)
@@ -12,11 +11,21 @@ class King < Piece
   end
 
   def valid_castling?(new_x, new_y)
-    rook_file = 1 if new_x == 3
-    rook_file = 8 if new_x == 7
-    return false if obstructed?(rook_file, new_y)
     return false if moved?
+    return false unless nth_rank(1) == new_y
+    return false unless new_x == 3 || new_x == 7
+    rook_file(new_x, new_y)
+  end
+
+  def nth_rank(n)
+    color == 'white' ? n : 9 - n
+  end
+
+  def rook_file(new_x, new_y)
+    rook_file = new_x == 3 ? 1 : 8
     rook = game.piece_at(rook_file, new_y)
     return false if rook.moved?
+    return false if obstructed?(rook_file, new_y)
+    true
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -15,5 +15,8 @@ class King < Piece
     rook_file = 1 if new_x == 3
     rook_file = 8 if new_x == 7
     return false if obstructed?(rook_file, new_y)
+    return false if moved?
+    rook = game.piece_at(rook_file, new_y)
+    return false if rook.moved?
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -2,7 +2,6 @@ class King < Piece
   def valid_move?(new_x, new_y)
     return false if off_board?(new_x, new_y)
     return false if current_square?(new_x, new_y)
-    # return false if in_check?(new_x, new_y)
 
     x_offset, y_offset = movement_by_axis(new_x, new_y)
     return true if (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,5 +1,4 @@
 class King < Piece
-  # This method does not disallow a king from moving into check.
   def valid_move?(new_x, new_y)
     return false if off_board?(new_x, new_y)
     return false if current_square?(new_x, new_y)
@@ -7,25 +6,61 @@ class King < Piece
     x_offset, y_offset = movement_by_axis(new_x, new_y)
     return true if (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)
 
+    in_check?(new_x, new_y)
+
     valid_castling?(new_x, new_y)
   end
 
+  # Determine if the king is being moved into a position resulting in check
+  def in_check?(new_x, new_y)
+    opponent_color = (color == 'white') ? 'black' : 'white'
+    live_pieces = game.pieces.where(color: opponent_color)
+    live_pieces.each do |piece|
+      return false if piece.valid_move?
+    end
+  end
+
+  # Determine if castling is allowed.
   def valid_castling?(new_x, new_y)
+    # The right to castle has been lost if the king has moved.
     return false if moved?
+
+    # Castling is permitted if the king and the chosen rook are on the player's first rank.
     return false unless nth_rank(1) == new_y
+
+    # Castling is not permitted unless the king moves two spaces along the same rank.
     return false unless new_x == 3 || new_x == 7
+
+    # Castling is not permitted if the rook has moved, or if there are any obstructions.
     rook_file(new_x, new_y)
   end
 
+  # Ensures that Castling is only permitted on the first rank relative to the player.
   def nth_rank(n)
     color == 'white' ? n : 9 - n
   end
 
+  # Castling helper method.
   def rook_file(new_x, new_y)
+    # Set the file for the rook to 1 if the player's intent is to Castle to their left,
+    # otherwise it will be set to eight.
     rook_file = new_x == 3 ? 1 : 8
     rook = game.piece_at(rook_file, new_y)
+
+    # The right to castle has been lost if the rook has moved earlier in the game.
     return false if rook.moved?
+
+    # Castling is prevented temporarily if there is any piece between the king and the rook.
     return false if obstructed?(rook_file, new_y)
     true
   end
+
+  # Castling is prevented temporarily:
+  # if the square on which the king stands, or the square which it must cross,
+  # or the square which it is to occupy, is attacked by one or more of the
+  # opponent's pieces.
+  # def threatened_squares
+  # make sure that the following squares are not being attacked
+  #   (3..5) || (5..7)
+  # end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -10,6 +10,14 @@ class King < Piece
     valid_castling?(new_x, new_y)
   end
 
+  # This is an addition to the move_to! method in the Piece model.
+  # It determines which rook is to be castled and moves it to the appropriate square.
+  def move_to!(new_x, new_y)
+    rook_file = (new_x == 3) ? 4 : 6
+    castled_rook = game.piece_at(rook_file, new_y)
+    castled_rook.move_to!(rook_file, new_y)
+  end
+
   private
 
   # Determine if castling is allowed.
@@ -38,7 +46,7 @@ class King < Piece
     rook_file = new_x == 3 ? 1 : 8
 
     # Guard against the rook's square being empty.
-    return false if game.piece_at(rook_file, new_y) == nil
+    return false if game.piece_at(rook_file, new_y).nil?
 
     # Assign a variable to the piece found in the rook's square. This handles either situation
     # whether the piece is a rook or not.

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -6,8 +6,14 @@ class King < Piece
     return false if current_square?(new_x, new_y)
 
     x_offset, y_offset = movement_by_axis(new_x, new_y)
-    return false unless (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)
+    return true if (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)
 
-    true
+    valid_castling?(new_x, new_y)
+  end
+
+  def valid_castling?(new_x, new_y)
+    rook_file = 1 if new_x == 3
+    rook_file = 8 if new_x == 7
+    return false if obstructed?(rook_file, new_y)
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -2,23 +2,16 @@ class King < Piece
   def valid_move?(new_x, new_y)
     return false if off_board?(new_x, new_y)
     return false if current_square?(new_x, new_y)
+    # return false if in_check?(new_x, new_y)
 
     x_offset, y_offset = movement_by_axis(new_x, new_y)
     return true if (-1..1).cover?(x_offset) && (-1..1).cover?(y_offset)
 
-    in_check?(new_x, new_y)
-
     valid_castling?(new_x, new_y)
   end
 
-  # Determine if the king is being moved into a position resulting in check
-  def in_check?(new_x, new_y)
-    opponent_color = (color == 'white') ? 'black' : 'white'
-    live_pieces = game.pieces.where(color: opponent_color)
-    live_pieces.each do |piece|
-      return false if piece.valid_move?
-    end
-  end
+  private
+
 
   # Determine if castling is allowed.
   def valid_castling?(new_x, new_y)
@@ -42,7 +35,7 @@ class King < Piece
 
   # Castling helper method.
   def rook_file(new_x, new_y)
-    # Set the file for the rook to 1 if the player's intent is to Castle to their left,
+    # Set the file for the rook to 1 if the player's intent is to Castle queen-side,
     # otherwise it will be set to eight.
     rook_file = new_x == 3 ? 1 : 8
     rook = game.piece_at(rook_file, new_y)
@@ -55,12 +48,12 @@ class King < Piece
     true
   end
 
-  # Castling is prevented temporarily:
-  # if the square on which the king stands, or the square which it must cross,
-  # or the square which it is to occupy, is attacked by one or more of the
-  # opponent's pieces.
-  # def threatened_squares
-  # make sure that the following squares are not being attacked
-  #   (3..5) || (5..7)
-  # end
-end
+  # Helper method used to determine if a particular square is under potential attack
+  def square_threatened?(destination_x, destination_y)
+    opponent_color = (color == 'white') ? 'black' : 'white'
+    enemy_pieces = game.pieces.where(color: opponent_color)
+    enemy_pieces.each do |piece|
+      return true if piece.valid_move?(destination_x, destination_y)
+    end
+    false
+  end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -57,3 +57,18 @@ class King < Piece
     end
     false
   end
+
+  # Castling is prevented temporarily:
+  # if the square on which the king stands, or the square which it must cross,
+  # or the square which it is to occupy, is attacked by one or more of the opponent's pieces.
+  def king_traversal_under_attack?(new_x, new_y)
+    # The argument for new_x will be either 3 or 7 if castling is attempted.
+    king_file_array = (new_x == 3) ? [3, 4, 5] : [5, 6, 7]
+
+    # File is a chess term that's analogous to x_coord
+    king_file_array.each do |file|
+      return true if square_threatened?(file, new_y)
+    end
+    false
+  end
+end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -22,7 +22,7 @@ class Piece < ActiveRecord::Base
       destination_piece.destroy
     end
 
-    update_attributes!(x_coord: destination_x, y_coord: destination_y)
+    update_attributes!(x_coord: destination_x, y_coord: destination_y, moved: true)
   end
 
   def valid_move?

--- a/db/migrate/20160605185936_add_moved_to_pieces.rb
+++ b/db/migrate/20160605185936_add_moved_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddMovedToPieces < ActiveRecord::Migration
+  def change
+    add_column :pieces, :moved, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160522191002) do
+ActiveRecord::Schema.define(version: 20160605185936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20160522191002) do
     t.integer "x_coord"
     t.integer "y_coord"
     t.string  "img"
+    t.boolean "moved",      default: false
   end
 
   add_index "pieces", ["game_id"], name: "index_pieces_on_game_id", using: :btree

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -1,0 +1,301 @@
+require 'rails_helper'
+
+RSpec.describe King, type: :model do
+  describe '.valid_move?' do
+    context 'when called by white king' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @white_king = King.create(x_coord: 5, y_coord: 1, color: 'white')
+        @white_rook = Rook.create(x_coord: 1, y_coord: 1, color: 'white')
+        @game.pieces << @white_king
+        @game.pieces << @white_rook
+      end
+
+      context 'castling move not permitted if the king has moved previously' do
+        it 'returns false after attempting to castle' do
+          @white_king.move_to!(5, 2)
+          @white_king.move_to!(5, 1)
+          expect(@white_king.move_to!(3, 1)).to be(false)
+        end
+      end
+
+      context 'castling not permitted unless the king moves 2 spaces along the same rank' do
+        it 'returns false after moving the white king 3 squares' do
+          expect(@white_king.move_to!(2, 1)).to be(false)
+        end
+      end
+    end
+
+    context 'when called by black king' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @black_king = King.create(x_coord: 5, y_coord: 8, color: 'black')
+        @black_rook = Rook.create(x_coord: 8, y_coord: 8, color: 'black')
+        @game.pieces << @black_king
+        @game.pieces << @black_rook
+      end
+
+      context 'castling move not permitted if the king has moved previously' do
+        it 'returns false after attempting to castle' do
+          @black_king.move_to!(6, 7)
+          @black_king.move_to!(5, 8)
+          expect(@black_king.move_to!(7, 8)).to be(false)
+        end
+      end
+
+      context 'castling not permitted unless the king moves 2 spaces along the same rank' do
+        it 'returns false after moving the black king 3 squares' do
+          expect(@black_king.move_to!(8, 8)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe '.move_to!' do
+    context 'when called by white king' do
+      it 'moves rook to kingside castled position' do
+        game = Game.create
+        game.pieces.each(&:destroy)
+        white_king = King.create(x_coord: 5, y_coord: 1, color: 'white')
+        white_rook = Rook.create(x_coord: 8, y_coord: 1, color: 'white')
+        game.pieces << white_king
+        game.pieces << white_rook
+
+        white_king.move_to!(7, 1)
+        white_rook.reload
+        expect(white_rook.x_coord).to eq(6)
+      end
+    end
+
+    context 'when called by white king' do
+      it 'moves rook to queenside castled position' do
+        game = Game.create
+        game.pieces.each(&:destroy)
+        white_king = King.create(x_coord: 5, y_coord: 1, color: 'white')
+        white_rook = Rook.create(x_coord: 1, y_coord: 1, color: 'white')
+        game.pieces << white_king
+        game.pieces << white_rook
+
+        white_king.move_to!(3, 1)
+        white_rook.reload
+        expect(white_rook.x_coord).to eq(4)
+      end
+    end
+
+    context 'when called by black king' do
+      it 'moves rook to kingside castled position' do
+        game = Game.create
+        game.pieces.each(&:destroy)
+        black_king = King.create(x_coord: 5, y_coord: 8, color: 'black')
+        black_rook = Rook.create(x_coord: 8, y_coord: 8, color: 'black')
+        game.pieces << black_king
+        game.pieces << black_rook
+
+        black_king.move_to!(7, 8)
+        black_rook.reload
+        expect(black_rook.x_coord).to eq(6)
+      end
+    end
+
+    context 'when called by black king' do
+      it 'moves rook to queenside castled position' do
+        game = Game.create
+        game.pieces.each(&:destroy)
+        black_king = King.create(x_coord: 5, y_coord: 8, color: 'black')
+        black_rook = Rook.create(x_coord: 1, y_coord: 8, color: 'black')
+        game.pieces << black_king
+        game.pieces << black_rook
+
+        black_king.move_to!(3, 8)
+        black_rook.reload
+        expect(black_rook.x_coord).to eq(4)
+      end
+    end
+  end
+
+  describe 'rook_requirements_met?' do
+    context 'for white' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @white_king = King.create(x_coord: 5, y_coord: 1, color: 'white')
+        @white_rook = Rook.create(x_coord: 8, y_coord: 1, color: 'white')
+        @game.pieces << @white_king
+        @game.pieces << @white_rook
+      end
+
+      context 'Rook has moved, and its original square is unoccupied' do
+        it 'returns false' do
+          @white_rook.move_to!(8, 2)
+          expect(@white_king.valid_move?(7, 1)).to eq(false)
+        end
+      end
+
+      context 'Rook has moved and another piece is in its original position' do
+        it 'returns false' do
+          white_bishop = Bishop.create(x_coord: 8, y_coord: 1, color: 'white')
+          white_bishop.moved?
+          @white_rook.move_to!(8, 2)
+          expect(@white_king.valid_move?(7, 1)).to eq(false)
+        end
+      end
+
+      context 'when the rook has moved and returned to its original position' do
+        it 'returns false' do
+          @white_rook.move_to!(8, 2)
+          @white_rook.move_to!(8, 1)
+          expect(@white_king.valid_move?(7, 1)).to eq(false)
+        end
+      end
+
+      context 'neither king nor rook have moved, castling not permitted since path is obstructed by knight' do
+        it 'returns false' do
+          white_knight = @game.knights.create(x_coord: 7, y_coord: 1, color: 'white')
+          white_knight.moved?
+          expect(@white_king.valid_move?(7, 1)).to eq(false)
+        end
+      end
+
+      context 'neither king nor rook have moved, but path obstructed by bishop' do
+        it 'returns true' do
+          white_bishop = @game.bishops.create(x_coord: 6, y_coord: 1, color: 'white')
+          white_bishop.moved?
+          expect(@white_king.valid_move?(7, 1)).to be(false)
+        end
+      end
+    end
+
+    context 'for black' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @black_king = King.create(x_coord: 5, y_coord: 8, color: 'black')
+        @black_rook = Rook.create(x_coord: 1, y_coord: 8, color: 'black')
+        @game.pieces << @black_king
+        @game.pieces << @black_rook
+      end
+
+      context 'Rook has moved, and its original square is unoccupied' do
+        it 'returns false' do
+          @black_rook.move_to!(1, 7)
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+
+      context 'Rook has moved and another piece is in its original position' do
+        it 'returns false' do
+          @black_rook.move_to!(1, 7)
+          black_queen = Queen.create(x_coord: 8, y_coord: 1, color: 'black')
+          black_queen.moved?
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+
+      context 'when the rook has moved and returned to its original position' do
+        it 'returns false' do
+          @black_rook.move_to!(1, 4)
+          @black_rook.move_to!(1, 8)
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+
+      context 'castling not permitted since path is obstructed by queen' do
+        it 'returns false' do
+          black_queen = @game.queens.create(x_coord: 4, y_coord: 8, color: 'black')
+          black_queen.moved?
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+
+      context 'castling not permitted since path is obstructed by bishop' do
+        it 'returns false' do
+          black_bishop = @game.bishops.create(x_coord: 3, y_coord: 8, color: 'black')
+          black_bishop.moved?
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+
+      context 'castling not permitted since path is obstructed by knight' do
+        it 'returns false' do
+          black_knight = @game.knights.create(x_coord: 2, y_coord: 8, color: 'black')
+          black_knight.moved?
+          expect(@black_king.valid_move?(3, 8)).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe 'king_traversal_under_attack?' do
+    context 'for black' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @black_king = King.create(x_coord: 5, y_coord: 8, color: 'black')
+        @black_rook = Rook.create(x_coord: 1, y_coord: 8, color: 'black')
+        @game.pieces << @black_king
+        @game.pieces << @black_rook
+      end
+
+      context 'The king is directly threatened' do
+        it 'returns true' do
+          white_rook = @game.rooks.create(x_coord: 5, y_coord: 4, color: 'white')
+          white_rook.moved?
+          expect(@black_king.valid_move?(3, 8)).to be(false)
+        end
+      end
+
+      context 'The 1st square the king must traverse for castling is threatened' do
+        it 'returns true' do
+          white_bishop = @game.bishops.create(x_coord: 2, y_coord: 6, color: 'white')
+          white_bishop.moved?
+          expect(@black_king.valid_move?(3, 8)).to be(false)
+        end
+      end
+
+      context 'The 2nd square the king must traverse for castling is threatened' do
+        it 'returns true' do
+          white_queen = @game.queens.create(x_coord: 3, y_coord: 6, color: 'white')
+          white_queen.moved?
+          expect(@black_king.valid_move?(3, 8)).to be(false)
+        end
+      end
+    end
+
+    context 'for white' do
+      before(:each) do
+        @game = Game.create
+        @game.pieces.each(&:destroy)
+        @white_king = King.create(x_coord: 5, y_coord: 1, color: 'white')
+        @white_rook = Rook.create(x_coord: 8, y_coord: 1, color: 'white')
+        @game.pieces << @white_king
+        @game.pieces << @white_rook
+      end
+
+      context 'The king is directly threatened' do
+        it 'returns true' do
+          black_knight = @game.knights.create(x_coord: 4, y_coord: 3, color: 'black')
+          black_knight.moved?
+          expect(@white_king.valid_move?(7, 1)).to be(false)
+        end
+      end
+
+      context 'The 1st square the king must traverse for castling is under threat' do
+        it 'returns true' do
+          black_pawn = @game.pawns.create(x_coord: 7, y_coord: 2, color: 'black')
+          black_pawn.moved?
+          expect(@white_king.valid_move?(7, 1)).to be(false)
+        end
+      end
+
+      context 'The 2nd square the king must traverse for castling is threatened' do
+        it 'returns true' do
+          black_rook = @game.rooks.create(x_coord: 7, y_coord: 8, color: 'black')
+          black_rook.moved?
+          expect(@white_king.valid_move?(7, 1)).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This branch introduces [castling](https://en.wikipedia.org/wiki/Castling). This allows a player to move their king and rook only if certain requirements are met, as mentioned in the previously linked Wikipedia article:
- The king and the chosen rook are on the player's first rank.
- Neither the king nor the chosen rook has previously moved.
- There are no pieces between the king and the chosen rook.
- The king is not currently in check.
- The king does not pass through a square that is attacked by an enemy piece.
- The king does not end up in check. (True of any legal move.)

![castling](https://cloud.githubusercontent.com/assets/16200483/15982045/9dd16b6c-2f4c-11e6-9dc6-e6af52464992.gif)

This branch does the following:
- Adds a moved column to the pieces table, which helps determine whether a piece has moved during the course of a game.
- Modifies the parameters for update_attributes! for the move_to! method within the Piece model.
- Introduces valid_castling? to the King class's valid_move? method.
- Adds a King-class move_to! method that places the rook in its appropriate position to complete the castling move, if all of the aforementioned requirements are met.
- Includes 25 RSpec tests relevant to castling (found within app/spec/models/king_spec.rb).
