### PR TITLE
Automatically migrate test database before tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,9 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
+# Automatically run migrations on the test database if they're needed.
+ActiveRecord::Migrator.migrate(File.join(Rails.root, 'db/migrate'))
+
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending!


### PR DESCRIPTION
Just going through the TDD unit in the main curriculum. This addition is from [the Stack Overflow answer](http://stackoverflow.com/a/22321132) mentioned in Lesson 7.

When RSpec is run, this line automatically migrates the test database, if there are any pending migrations. (Travis CI does this for us already, but this will prevent some errors when running RSpec locally.
