### PR TITLE
Indicate Rank and File on the edges of the chessboard.

### DIFF
--- a/app/assets/javascripts/master.js
+++ b/app/assets/javascripts/master.js
@@ -28,8 +28,3 @@ function handleDragStop( event, ui ) {
     data: { piece: { x_coord: destination_x, y_coord: destination_y } }
   });
 }
-
-function gameStartMessage() {
-  $( ".player-turn" ).html( "White has the first move" )
-                     .addClass( "animated fadeInDown white-player-turn", 1000 );
-}

--- a/app/assets/javascripts/master.js
+++ b/app/assets/javascripts/master.js
@@ -28,3 +28,8 @@ function handleDragStop( event, ui ) {
     data: { piece: { x_coord: destination_x, y_coord: destination_y } }
   });
 }
+
+function gameStartMessage() {
+  $( ".player-turn" ).html( "White has the first move" )
+                     .addClass( "animated fadeInDown white-player-turn", 1000 );
+}

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -3,6 +3,7 @@ $rank-file-font-size: 1.6em;
 
 .table-surface {
   width: 100%;
+  padding: 3em 0;
   background: url('/assets/upfeathers.png');
 }
 
@@ -234,7 +235,7 @@ $kingInCheckMessage-iphone5: .8em;
 
 .white-player-turn {
   font-size: 1.4em;
-  color: #9CAAA8;
+  color: #858383;
   text-transform: capitalize;
 }
 

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -1,6 +1,5 @@
 $square-size: 70px;
-$rank-file-font-size: 2em;
-$rank-file-letter-spacing: 0.75em;
+$rank-file-font-size: 1.6em;
 
 .table-surface {
   width: 100%;
@@ -34,9 +33,8 @@ $rank-file-letter-spacing: 0.75em;
 
 .file-indicator {
   font-size: $rank-file-font-size;
-  padding-left: 5%;
-  padding-top: 2%;
-  letter-spacing: $rank-file-letter-spacing;
+  padding: 2% 0 1% 5%;
+  letter-spacing: 1.02em;
   text-shadow: 0px 2px 3px #555;
 }
 
@@ -51,18 +49,18 @@ $rank-file-letter-spacing: 0.75em;
 /* tablet held in portrait */
 @media (max-width: 768px) {
   .file-indicator {
-    font-size: 1.9em;
-    letter-spacing: 0.71em;
-    padding-left: 5%;
+    font-size: $rank-file-font-size;
+    letter-spacing: 1.18em;
+    padding: 2% 0 1% 3%;
   }
 }
 
 /* tablet held in landscape */
 @media (min-width: 769px) and (max-width: 1024px) {
   .file-indicator {
-    font-size: 1.9em;
-    letter-spacing: 0.93em;
-    padding-left: 5%;
+    font-size: $rank-file-font-size;
+    letter-spacing: 1.2em;
+    padding: 2% 0 1% 3%;
   }
 }
 
@@ -78,28 +76,47 @@ $square-size-tablet: 60px;
 $rank-file-font-size-cell-portrait: 1em;
 /* iphone5 held in portrait */
 @media (max-width: 321px) {
+  .rank-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    /*padding-left: 9%*/;
+  }
+}
+
+@media (max-width: 321px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
-    letter-spacing: 0.37em;
-    padding-left: 9%;
+    letter-spacing: 0.52em;
+    padding-left: 3%;
   }
 }
 
 /* iPhone 6 and s5 held in portrait */
 @media (min-width: 359px) and (max-width: 376px) {
+  .rank-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+  }
+}
+
+@media (min-width: 359px) and (max-width: 376px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
-    letter-spacing: 0.53em;
-    padding-left: 8%;
+    letter-spacing: 0.70em;
+    padding-left: 4%;
   }
 }
 
 /* Nexus5x iPhone6+ Nexus6p held in portrait */
 @media (min-width: 377px) and (max-width: 436px) {
+  .rank-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+  }
+}
+
+@media (min-width: 377px) and (max-width: 436px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
-    letter-spacing: 0.70em;
-    padding-left: 7%;
+    letter-spacing: 0.65em;
+    padding-left: 3%;
   }
 }
 /*  -----------------------------------------------  */
@@ -161,8 +178,7 @@ $square-size-mobile: 30px;
 }
 
 .warning {
-  font-size: 1.8em;
-  padding-bottom: .48em;
+  padding-bottom: 4%;
 }
 
 .kingInCheckMessage {

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -13,13 +13,19 @@ $square-size: 70px;
   border: 1px solid #ccc;
   border-color: #e4e4e4 #bebebd #bebebd #e4e4e4;
 }
-
-.white-coords {
-
+.file-indicator {
+  font-size: 2em;
+  padding-left: 2%;
+  padding-top: 2%;
+  letter-spacing: 0.84em;
 }
 
-.black-coords {
-  
+.white-letters {
+  color: #fff;
+}
+
+.black-letters {
+  color: black;
 }
 
 table {
@@ -65,7 +71,7 @@ $square-size-tablet: 60px;
 }
 
 .boardTopBottom {
-  padding: 1em 0
+
 }
 
 .hoveredSquare {

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -47,7 +47,7 @@ $rank-file-font-size: 1.6em;
 }*/
 
 /* tablet held in portrait */
-@media (max-width: 768px) {
+@media (min-width: 741px) and (max-width: 768px) {
   .file-indicator {
     font-size: $rank-file-font-size;
     letter-spacing: 1.18em;
@@ -56,7 +56,7 @@ $rank-file-font-size: 1.6em;
 }
 
 /* tablet held in landscape */
-@media (min-width: 769px) and (max-width: 1024px) {
+@media (min-width: 774px) and (max-width: 1024px) {
   .file-indicator {
     font-size: $rank-file-font-size;
     letter-spacing: 1.2em;
@@ -75,13 +75,20 @@ $square-size-tablet: 60px;
 /* ---------  optimizations for cell-phones  ----------- */
 $rank-file-font-size-cell-portrait: 1em;
 /* iphone5 held in portrait */
-@media (max-width: 321px) {
+@media (max-width: 329px) {
   .rank-indicator {
     font-size: $rank-file-font-size-cell-portrait;
-    /*padding-left: 9%*/;
   }
 }
 
+/* device held in portrait */
+@media (min-width: 330px) and (max-width: 760px) {
+  .rank-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+  }
+}
+
+/* iphone5 held in portrait */
 @media (max-width: 321px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
@@ -90,13 +97,16 @@ $rank-file-font-size-cell-portrait: 1em;
   }
 }
 
-/* iPhone 6 and s5 held in portrait */
-@media (min-width: 359px) and (max-width: 376px) {
-  .rank-indicator {
+/* iphone5 held in L A N D S C A P E */
+@media (min-width: 549px) and (max-width: 569px) {
+  .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.70em;
+    padding-left: 2%;
   }
 }
 
+/* iPhone 6 and s5 held in portrait */
 @media (min-width: 359px) and (max-width: 376px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
@@ -105,18 +115,37 @@ $rank-file-font-size-cell-portrait: 1em;
   }
 }
 
-/* Nexus5x iPhone6+ Nexus6p held in portrait */
-@media (min-width: 377px) and (max-width: 436px) {
-  .rank-indicator {
+/* iPhone 6 and s5 held in L A N D S C A P E */
+@media (min-width: 570px) and (max-width: 679px) {
+  .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.70em;
+    padding-left: 2%;
   }
 }
 
+/* Nexus5x iPhone6+ Nexus6p held in portrait */
 @media (min-width: 377px) and (max-width: 436px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
     letter-spacing: 0.65em;
     padding-left: 3%;
+  }
+}
+
+/* Nexus5x iPhone6+ held in L A N D S C A P E */
+@media (min-width: 720px) and (max-width: 740px) {
+  .file-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.68em;
+    padding-left: 2%;
+  }
+}
+
+/* Nexus6P held in L A N D S C A P E */
+@media (min-width: 770px) and (max-width: 780px) {
+  .file-indicator {
+    letter-spacing: 0.92em;
   }
 }
 /*  -----------------------------------------------  */

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -17,7 +17,7 @@ $rank-file-font-size: 1.6em;
 
 /* ---- indicators for rank and file on board edges ------- */
 .white-letters {
-  color: #fff;
+  color: rgba(255, 255, 255, 0.84);
 }
 
 .black-letters {
@@ -28,14 +28,16 @@ $rank-file-font-size: 1.6em;
   font-size: $rank-file-font-size;
   text-align: center;
   padding-right: 0.4em;
-  text-shadow: 0px 2px 3px #555;
+  text-shadow: rgba(0, 0, 0, 0.45) 0 -1px 0.025em, rgba(255, 255, 255, 0.75) 0 1px 0.025em;
+  /*text-shadow: 0px 2px 3px #555;*/
 }
 
 .file-indicator {
   font-size: $rank-file-font-size;
   padding: 2% 0 1% 5%;
   letter-spacing: 1.02em;
-  text-shadow: 0px 2px 3px #555;
+  text-shadow: rgba(0, 0, 0, 0.45) 0 -1px 0.025em, rgba(255, 255, 255, 0.75) 0 1px 0.025em;
+  /*text-shadow: 0px 2px 3px #555;*/
 }
 
 /* --------- optimizations for tablets ----------- */

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -41,15 +41,9 @@ $rank-file-font-size: 1.6em;
 }
 
 /* --------- optimizations for tablets ----------- */
-/*$table-surface-width-tablet-landscape: 76%;
-@media (min-width: 761px) and (max-width: 1024px) {
-  .table-surface {
-    width: $table-surface-width-tablet-landscape;
-  }
-}*/
 
 /* tablet held in portrait */
-@media (min-width: 741px) and (max-width: 768px) {
+@media (min-width: 760px) and (max-width: 769px) {
   .file-indicator {
     font-size: $rank-file-font-size;
     letter-spacing: 1.18em;
@@ -58,7 +52,7 @@ $rank-file-font-size: 1.6em;
 }
 
 /* tablet held in landscape */
-@media (min-width: 774px) and (max-width: 1024px) {
+@media (min-width: 775px) and (max-width: 1024px) {
   .file-indicator {
     font-size: $rank-file-font-size;
     letter-spacing: 1.2em;
@@ -84,7 +78,7 @@ $rank-file-font-size-cell-portrait: 1em;
 }
 
 /* device held in portrait */
-@media (min-width: 330px) and (max-width: 760px) {
+@media (min-width: 330px) and (max-width: 759px) {
   .rank-indicator {
     font-size: $rank-file-font-size-cell-portrait;
   }
@@ -109,7 +103,7 @@ $rank-file-font-size-cell-portrait: 1em;
 }
 
 /* iPhone 6 and s5 held in portrait */
-@media (min-width: 359px) and (max-width: 376px) {
+@media (min-width: 359px) and (max-width: 548px) {
   .file-indicator {
     font-size: $rank-file-font-size-cell-portrait;
     letter-spacing: 0.70em;
@@ -144,8 +138,16 @@ $rank-file-font-size-cell-portrait: 1em;
   }
 }
 
+@media (min-width: 680px) and (max-width: 719px) {
+  .file-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.70em;
+    padding-left: 2%;
+  }
+}
+
 /* Nexus6P held in L A N D S C A P E */
-@media (min-width: 770px) and (max-width: 780px) {
+@media (min-width: 770px) and (max-width: 774px) {
   .file-indicator {
     letter-spacing: 0.92em;
   }

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -231,6 +231,7 @@ $kingInCheckMessage-iphone5: .8em;
 
 .blushing-king {
   background: url('/assets/red_king.png');
+  background-size: contain;
 }
 
 .white-player-turn {

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -1,4 +1,6 @@
 $square-size: 70px;
+$rank-file-font-size: 2em;
+$rank-file-letter-spacing: 0.75em;
 
 .table-surface {
   width: 100%;
@@ -13,13 +15,8 @@ $square-size: 70px;
   border: 1px solid #ccc;
   border-color: #e4e4e4 #bebebd #bebebd #e4e4e4;
 }
-.file-indicator {
-  font-size: 2em;
-  padding-left: 2%;
-  padding-top: 2%;
-  letter-spacing: 0.84em;
-}
 
+/* ---- indicators for rank and file on board edges ------- */
 .white-letters {
   color: #fff;
 }
@@ -28,15 +25,104 @@ $square-size: 70px;
   color: black;
 }
 
+.rank-indicator {
+  font-size: $rank-file-font-size;
+}
+
+.file-indicator {
+  font-size: $rank-file-font-size;
+  padding-left: 5%;
+  padding-top: 2%;
+  letter-spacing: $rank-file-letter-spacing;
+  text-shadow: 0px 2px 3px #555;
+}
+
+/* --------- optimizations for tablets ----------- */
+/*$table-surface-width-tablet-landscape: 76%;
+@media (min-width: 761px) and (max-width: 1024px) {
+  .table-surface {
+    width: $table-surface-width-tablet-landscape;
+  }
+}*/
+
+/* tablet held in portrait */
+@media (max-width: 768px) {
+  .file-indicator {
+    font-size: 1.9em;
+    letter-spacing: 0.71em;
+    padding-left: 5%;
+  }
+}
+
+/* tablet held in landscape */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .file-indicator {
+    font-size: 1.9em;
+    letter-spacing: 0.93em;
+    padding-left: 5%;
+  }
+}
+
+$square-size-tablet: 60px;
+@media (min-width: 768px) and (max-width: 1024px) {
+  .square {
+    width: $square-size-tablet;
+    height: $square-size-tablet;
+  }
+}
+
+/* ---------  optimizations for cell-phones  ----------- */
+$rank-file-font-size-cell-portrait: 1em;
+/* iphone5 held in portrait */
+@media (max-width: 321px) {
+  .file-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.37em;
+    padding-left: 9%;
+  }
+}
+
+/* iPhone 6 and s5 held in portrait */
+@media (min-width: 359px) and (max-width: 376px) {
+  .file-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.53em;
+    padding-left: 8%;
+  }
+}
+
+/* Nexus5x iPhone6+ Nexus6p held in portrait */
+@media (min-width: 377px) and (max-width: 436px) {
+  .file-indicator {
+    font-size: $rank-file-font-size-cell-portrait;
+    letter-spacing: 0.70em;
+    padding-left: 7%;
+  }
+}
+/*  -----------------------------------------------  */
+
 table {
   margin: 0 auto;
 }
 
+/*eliminate the border for the table column that has the rank numbers*/
+td.rank-indicator {
+  border: none;
+}
 
-table tr:nth-child(odd) td:nth-child(even) {
+td.squash-me {
+  border: none;
+}
+
+/*Starting from the top [ row 1 ( *or rank-8 ) ], handle rows 2, 4, 6, and 8 
+then take each even column (remember that there is the hidden column for the
+rank-indicator cells) and set the dark background */
+table tr:nth-child(n+2):nth-child(-n+8):nth-child(even) td:nth-child(n+2):nth-child(-n+9):nth-child(even) {
   background: url('/assets/med_birdseye_70px.jpg');
 }
-table tr:nth-child(even) td:nth-child(odd) {
+
+/* Starting from the top [ row 1 ( *or rank-8 ) ], handle rows 1, 3, 5, and 7 */
+table tr:nth-child(n+1):nth-child(-n+8):nth-child(odd) td:nth-child(n+2):nth-child(-n+9):nth-child(odd) {
   background: url('/assets/med_birdseye_70px.jpg');
 }
 
@@ -62,14 +148,6 @@ $square-size-mobile: 30px;
   }
 }
 
-$square-size-tablet: 60px;
-@media (min-width: 761px) and (max-width: 1024px) {
-  .square {
-    width: $square-size-tablet;
-    height: $square-size-tablet;
-  }
-}
-
 .boardTopBottom {
 
 }
@@ -81,6 +159,7 @@ $square-size-tablet: 60px;
 
 .warning {
   font-size: 1.8em;
+  padding-bottom: .48em;
 }
 
 .kingInCheckMessage {

--- a/app/assets/stylesheets/game.css.scss
+++ b/app/assets/stylesheets/game.css.scss
@@ -27,6 +27,9 @@ $rank-file-letter-spacing: 0.75em;
 
 .rank-indicator {
   font-size: $rank-file-font-size;
+  text-align: center;
+  padding-right: 0.4em;
+  text-shadow: 0px 2px 3px #555;
 }
 
 .file-indicator {

--- a/app/helpers/game_helper.rb
+++ b/app/helpers/game_helper.rb
@@ -22,4 +22,8 @@ module GameHelper
   def add_squash_class(x)
     + " squash-me" if x == 9
   end
+
+  def add_rank_indicator_class(x)
+    + " rank-indicator center-text" if x == 0
+  end
 end

--- a/app/helpers/game_helper.rb
+++ b/app/helpers/game_helper.rb
@@ -24,6 +24,6 @@ module GameHelper
   end
 
   def add_rank_indicator_class(x)
-    + " rank-indicator center-text" if x == 0
+    + " rank-indicator center-text rank-and-file" if x == 0
   end
 end

--- a/app/helpers/game_helper.rb
+++ b/app/helpers/game_helper.rb
@@ -18,4 +18,8 @@ module GameHelper
     color = (piece.color == 'white') ? 'white' : 'black'
     return color + '-king' if piece.piece_type == 'King'
   end
+
+  def add_squash_class(x)
+    + " squash-me" if x == 9
+  end
 end

--- a/app/views/games/_chess_board.html.erb
+++ b/app/views/games/_chess_board.html.erb
@@ -16,4 +16,4 @@
 
     <% end %>
   </table>
-<p class="boardTopBottom file-indicator text-center col-xs-12">a b c d e f g h</p>
+<p class="boardTopBottom rank-and-file file-indicator text-center col-xs-12">a b c d e f g h</p>

--- a/app/views/games/_chess_board.html.erb
+++ b/app/views/games/_chess_board.html.erb
@@ -1,4 +1,4 @@
-<p class="boardTopBottom"></p>
+<p class="boardTopBottom letter-coordinate"></p>
 <div class="warning text-center">&nbsp</div>
   <table id="board">
     <% 8.downto(1) do |y| %>
@@ -11,4 +11,4 @@
       </tr>
     <% end %>
   </table>
-<p class="boardTopBottom"></p>
+<p class="boardTopBottom file-indicator text-center">A B C D E F G H</p>

--- a/app/views/games/_chess_board.html.erb
+++ b/app/views/games/_chess_board.html.erb
@@ -1,14 +1,18 @@
-<p class="boardTopBottom letter-coordinate"></p>
+<p class="boardTopBottom"></p>
 <div class="warning text-center">&nbsp</div>
   <table id="board">
+
     <% 8.downto(1) do |y| %>
       <tr>
-        <% 1.upto(8) do |x| %>
-          <td data-x="<%= x %>" data-y="<%= y %>"class="square">
+        <% 0.upto(9) do |x| %>
+          <td data-x="<%= x %>" data-y="<%= y %>
+          "class="square<%= + " rank-indicator center-text" if (x == 0) %>
+          <%= add_squash_class(x) %>" >
             <%= game_pieces(@game, x, y) %>
           </td>
         <% end %>
       </tr>
+
     <% end %>
   </table>
-<p class="boardTopBottom file-indicator text-center">A B C D E F G H</p>
+<p class="boardTopBottom file-indicator text-center col-xs-12">a b c d e f g h</p>

--- a/app/views/games/_chess_board.html.erb
+++ b/app/views/games/_chess_board.html.erb
@@ -6,9 +6,10 @@
       <tr>
         <% 0.upto(9) do |x| %>
           <td data-x="<%= x %>" data-y="<%= y %>
-          "class="square<%= + " rank-indicator center-text" if (x == 0) %>
-          <%= add_squash_class(x) %>" >
+              "class="square<%= add_rank_indicator_class(x) %>
+                            <%= add_squash_class(x) %>" >
             <%= game_pieces(@game, x, y) %>
+            <%= y if x == 0 %>
           </td>
         <% end %>
       </tr>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,11 +9,9 @@
 <div class="player-turn text-center"></div>
 
 <div class="container table-surface">
-  <div class="black-or-white-coords">
-    <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-xs-10 col-xs-offset-1" data-no-turbolink>
-      <!-- pull in the board from a partial -->
-      <%= render 'chess_board' %>
-    </div>
+  <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-xs-10 col-xs-offset-1" data-no-turbolink>
+    <!-- pull in the board from a partial -->
+    <%= render 'chess_board' %>
   </div>
 </div>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,14 +1,13 @@
 <h2 class="text-center">
   <% if !@game.black_player_id.nil? %>
-    <%= @white_player.email %><h3> vs </h3><%= @black_player.email %>
+    <%= @white_player.email %> vs <%= @black_player.email %>
   <% else %>
     <%= @white_player.email %> vs Someone
   <% end %>
 </h2>
 
-<div class="player-turn text-center"></div>
-
 <div class="container table-surface">
+  <div class="player-turn text-center"></div>
   <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-sm-10 
   col-sm-offset-1 col-xs-12" data-no-turbolink>
     <!-- pull in the board from a partial -->

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -30,7 +30,3 @@
     dragDrop();
   <% end %>
 </script>
-
-<script type="text/javascript">
-  gameStartMessage();
-</script>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="container table-surface">
   <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-sm-10 
-  col-sm-offset-1 col-xs-10 col-xs-offset-1" data-no-turbolink>
+  col-sm-offset-1 col-xs-12" data-no-turbolink>
     <!-- pull in the board from a partial -->
     <%= render 'chess_board' %>
   </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,7 +9,8 @@
 <div class="player-turn text-center"></div>
 
 <div class="container table-surface">
-  <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-xs-10 col-xs-offset-1" data-no-turbolink>
+  <div class="board-booyah-box col-lg-6 col-lg-offset-3 col-sm-10 
+  col-sm-offset-1 col-xs-10 col-xs-offset-1" data-no-turbolink>
     <!-- pull in the board from a partial -->
     <%= render 'chess_board' %>
   </div>
@@ -29,4 +30,8 @@
   <% if current_user.id == current_player_id %>
     dragDrop();
   <% end %>
+</script>
+
+<script type="text/javascript">
+  gameStartMessage();
 </script>

--- a/app/views/pieces/update.js.erb
+++ b/app/views/pieces/update.js.erb
@@ -12,13 +12,13 @@ $( ".board-booyah-box" ).html("<%= escape_javascript(render('games/chess_board')
 
 // Display a message indicating whether it's white or black's turn.
 <% if @game.white? %>
-  $( ".file-indicator" ).addClass( "animated fadeIn white-letters", 800 )
+  $( ".rank-and-file" ).addClass( "animated fadeIn white-letters", 800 )
                           .removeClass( "black-letters", "slow" );
 
   $( ".player-turn" ).html( "current move: white player" )
                      .addClass( "animated fadeInDown white-player-turn", 1000 );
 <% elsif @game.black? %>
-  $( ".file-indicator" ).removeClass( "white-letters", "slow" )
+  $( ".rank-and-file" ).removeClass( "white-letters", "slow" )
                           .addClass( "animated fadeIn black-letters", 800 );
 
   $( ".player-turn" ).html( "current move: black player" )

--- a/app/views/pieces/update.js.erb
+++ b/app/views/pieces/update.js.erb
@@ -2,8 +2,9 @@
 <% @game = @piece.game %>
 $( ".board-booyah-box" ).html("<%= escape_javascript(render('games/chess_board')) %>");
 
-// The following calls the function within master.js to make 
-// pieces draggable and squares droppable.
+// The following calls the function within master.js and limits 
+// making pieces draggable and squares droppable to only the player
+// who has the next move.
 <% current_player_id = @game.white? ? @game.white_player_id : @game.black_player_id %>
 <% if current_user.id == current_player_id %>
   dragDrop();
@@ -11,14 +12,14 @@ $( ".board-booyah-box" ).html("<%= escape_javascript(render('games/chess_board')
 
 // Display a message indicating whether it's white or black's turn.
 <% if @game.white? %>
-  $( ".black-or-white-coords" ).addClass( "animated fadeIn white-coords", 800 )
-                               .removeClass( "black-coords", "slow" );
+  $( ".file-indicator" ).addClass( "animated fadeIn white-letters", 800 )
+                          .removeClass( "black-letters", "slow" );
 
   $( ".player-turn" ).html( "current move: white player" )
                      .addClass( "animated fadeInDown white-player-turn", 1000 );
 <% elsif @game.black? %>
-  $( ".black-or-white-coords" ).addClass( "animated fadeIn black-coords", 800 )
-                               .removeClass( "white-coords", "slow" );
+  $( ".file-indicator" ).removeClass( "white-letters", "slow" )
+                          .addClass( "animated fadeIn black-letters", 800 );
 
   $( ".player-turn" ).html( "current move: black player" )
                      .addClass( "animated fadeInUp black-player-turn", 1000 );


### PR DESCRIPTION
This branch does the following:
- Indicate Rank and File on the left edge and bottom edge of the chessboard.
- Switch text-color from black to white for the rank and file indicators depending on whose turn it is.
  ![rank_and_file](https://cloud.githubusercontent.com/assets/16200483/16180351/bee4733e-3650-11e6-89b9-4fce2ebf1096.png)
- Add optimizations for displaying on smaller devices.
  *Identify a bug with the blushing king on a smaller display:

![blushing_king_bug](https://cloud.githubusercontent.com/assets/16200483/16202643/8e0a998e-36e4-11e6-90fc-af28934e3e88.png)
- Fix the bug with the blushing king so that a king in check looks correct on a smaller device:
  ![blushing_king_bug-fixed](https://cloud.githubusercontent.com/assets/16200483/16202497/e9d59594-36e3-11e6-8e6b-ed62ccc8bf66.png)
