### PR TITLE
Delete 20160627150901_add_last_request_at_to_users.rb

### DIFF
--- a/db/migrate/20160627150901_add_last_request_at_to_users.rb
+++ b/db/migrate/20160627150901_add_last_request_at_to_users.rb
@@ -1,5 +1,0 @@
-class AddLastRequestAtToUsers < ActiveRecord::Migration
-  def change
-    remove_column :users, :last_request_at, :datetime
-  end
-end


### PR DESCRIPTION
This file was causing an error when migrating (and during the Travis CI build).

The last_request_at column did not exist in the database at this point in the
migration series, so attempting to drop it causes a fatal error.
